### PR TITLE
Fix error when buliding client bundles with custom webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Bugpilot plugin for Next.js (App Router) automatically captures errors in y
 The easiest way to get started is to use our CLI Wizard. It will automatically install the plugin and configure your Next.js application:
 
 ```bash
-npx @bugpilot/wizard@latest install
+pnpm dlx @bugpilot/wizard@latest install
 ```
 
 ## Key Features
@@ -34,18 +34,18 @@ This table shows which error types are supported by the Bugpilot plugin for Next
 |---------------------------|----------------|--------------------------|
 | Server page               | Yes            | Yes                      |
 | Server component          | Yes            | Yes                      |
+| Client component / page   | Yes            | Yes                      |
 | Server form               | Yes            | Yes                      |
-| Server action             | Yes            | Yes                      |
-| Inline server action      | Yes            | Yes                      |
-| Client component          | Yes            | Yes                      |
-| Browser exceptions        | Yes            | No                       |
-| Errors in event handlers  | Yes            | No                       |
-| Middleware                | Yes            | Not supported in Next.js |
 | Layout                    | Yes            | Yes                      |
-| Root Layout errors        | Yes            | Yes (app/global-error.tsx) |
+| Root Layout               | Yes            | Yes                      |
+| Server action             | Yes            | No (*)                   |
+| Inline server action      | Yes            | No (*)                   |
+| Browser exceptions        | Yes            | No (*)                   |
+| Errors in event handlers  | Yes            | No (*)                   |
+| Middleware                | Yes            | Default Next.js Application Error |
 | API Routes                | No             | No                       |
 
-You can customize the error pages by updating the code in `app/error.tsx` and `app/global-error.tsx`.
+(*) Work in progress. For supported scenarios, you can customize the error pages by updating the code in `app/error.tsx` and `app/global-error.tsx` (for root layout errors).
 
 ## Customizations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugpilot/plugin-nextjs",
-  "version": "0.1.6",
+  "version": "0.18.0",
   "description": "Bugpilot for Next.js App Router",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Server exports:
 export { wrapServerFunction } from "./wrap-server-function";
 export { withBugpilot } from "./withBugpilot";
+export { captureError } from "./capture-error";
 
 // Client exports:
 export { Bugpilot } from "./client/Bugpilot";

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -39,6 +39,14 @@ export function webpackConfigFnFactory(
     };
 
     const { buildId, dev, isServer, nextRuntime } = context;
+
+    if (!isServer) {
+      // We don't wrap client code for performance reasons,
+      // client errors are still bubbled up to the closes error
+      // boundary (or error.tsx) and reported to Bugpilot.
+      return;
+    }
+
     const commonOptions: Omit<WebpackLoaderOptions, "kind"> = {
       buildId,
       dev,
@@ -47,69 +55,67 @@ export function webpackConfigFnFactory(
       debug: bugpilotConfig?.debug,
     };
 
-    if (isServer === true) {
-      // Wrap middleware
-      newConfigWithRules.module.rules.unshift({
-        test: /\/middleware.ts$/,
-        use: [
-          {
-            loader: serverFunctionLoaderPath,
-            options: {
-              ...commonOptions,
-              kind: "middleware",
-            } as WebpackLoaderOptions,
-          },
-        ],
-      });
+    // Wrap middleware
+    newConfigWithRules.module.rules.unshift({
+      test: /\/middleware.ts$/,
+      use: [
+        {
+          loader: serverFunctionLoaderPath,
+          options: {
+            ...commonOptions,
+            kind: "middleware",
+          } as WebpackLoaderOptions,
+        },
+      ],
+    });
 
-      // Wrap server components
-      newConfigWithRules.module.rules.unshift({
-        test: /\.tsx$/,
-        exclude:
-          /\/(page|layout|error|global-error|not-found|middleware|route|template|default).tsx$/,
-        use: [
-          {
-            loader: serverFunctionLoaderPath,
-            options: {
-              ...commonOptions,
-              kind: "server-component",
-            } as WebpackLoaderOptions,
-          },
-        ],
-      });
+    // Wrap server components
+    newConfigWithRules.module.rules.unshift({
+      test: /\.tsx$/,
+      exclude:
+        /\/(page|layout|error|global-error|not-found|middleware|route|template|default).tsx$/,
+      use: [
+        {
+          loader: serverFunctionLoaderPath,
+          options: {
+            ...commonOptions,
+            kind: "server-component",
+          } as WebpackLoaderOptions,
+        },
+      ],
+    });
 
-      // Wrap Server Actions and Inline Server Actions
-      newConfigWithRules.module.rules.unshift({
-        test: /\.(ts|tsx)$/,
-        exclude:
-          /\/(layout|error|global-error|not-found|middleware|route|template|default|api\/).tsx?$/,
-        include: /\/app\//,
-        use: [
-          {
-            loader: serverFunctionLoaderPath,
-            options: {
-              ...commonOptions,
-              kind: "server-action",
-            } as WebpackLoaderOptions,
-          },
-        ],
-      });
+    // Wrap Server Actions and Inline Server Actions
+    newConfigWithRules.module.rules.unshift({
+      test: /\.(ts|tsx)$/,
+      exclude:
+        /\/(layout|error|global-error|not-found|middleware|route|template|default|api\/).tsx?$/,
+      include: /\/app\//,
+      use: [
+        {
+          loader: serverFunctionLoaderPath,
+          options: {
+            ...commonOptions,
+            kind: "server-action",
+          } as WebpackLoaderOptions,
+        },
+      ],
+    });
 
-      // Wrap server pages
-      newConfigWithRules.module.rules.unshift({
-        test: /\/page.tsx$/,
-        include: /\/app\//,
-        use: [
-          {
-            loader: serverFunctionLoaderPath,
-            options: {
-              ...commonOptions,
-              kind: "page-component",
-            } as WebpackLoaderOptions,
-          },
-        ],
-      });
-    }
+    // Wrap server pages
+    newConfigWithRules.module.rules.unshift({
+      test: /\/page.tsx$/,
+      include: /\/app\//,
+      use: [
+        {
+          loader: serverFunctionLoaderPath,
+          options: {
+            ...commonOptions,
+            kind: "page-component",
+          } as WebpackLoaderOptions,
+        },
+      ],
+    });
 
     return newConfigWithRules;
   };

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -44,7 +44,7 @@ export function webpackConfigFnFactory(
       // We don't wrap client code for performance reasons,
       // client errors are still bubbled up to the closes error
       // boundary (or error.tsx) and reported to Bugpilot.
-      return;
+      return newConfigWithRules;
     }
 
     const commonOptions: Omit<WebpackLoaderOptions, "kind"> = {


### PR DESCRIPTION
This pull request includes the following commits:

- fix error when buliding client bundles with custom webpack config
- export captureError for use by error.tsx pages
- cleanup

