### PR TITLE
Use Proxy for wrapServerFunction 

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -10,7 +10,7 @@ Tests are run against a bare create-next-app project with the default configurat
 
 We also compare the bundle size, by looking at the output of the `next build` command.
 
-Hardware: Tests are run on an M1 Macbook Pro with 16GB of RAM.  
+Hardware: Tests are run on an M1 MacBook Pro with 16GB of RAM.  
 Results: Below you can find the most recent results.  
 
 ```bash

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,76 @@
+# Performance
+
+We regularly run performance tests to ensure that the performance of the application is not degraded when Bugpilot is installed and your app code is instrumented.
+We never instrument client-side code, so most of your components will not be affected by the instrumentation. We only instrument some server-side code.
+
+## How to test
+
+We use `wrk` (`brew install wrk`) to run performance tests.  
+Tests are run against a bare create-next-app project with the default configuration, and Bugpilot installed using the `@bugpilot/wizard` package.
+
+We also compare the bundle size, by looking at the output of the `next build` command.
+
+Hardware: Tests are run on an M1 Macbook Pro with 16GB of RAM.  
+Results: Below you can find the most recent results.  
+
+```bash
+wrk -t12 -c400 -d30s http://localhost:3200/
+```
+
+## Test results
+
+### 2024-01-24
+
+#### Without Bugpilot
+
+Bundle Size:
+
+```text
+Route (app)                              Size     First Load JS
+┌ ○ /                                    5.15 kB        89.3 kB
+└ ○ /_not-found                          882 B            85 kB
++ First Load JS shared by all            84.2 kB
+  ├ chunks/184-d3bb186aac44da98.js       28.9 kB
+  ├ chunks/30b509c0-f3503c24f98f3936.js  53.4 kB
+  └ other shared chunks (total)          1.87 kB
+```
+
+Requests throughput:
+
+```text
+Running 30s test @ http://localhost:3200/
+  12 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    13.97ms   24.90ms 706.27ms   99.19%
+    Req/Sec   658.97     62.39     1.51k    90.80%
+  235929 requests in 30.10s, 3.49GB read
+Requests/sec:   7838.08
+Transfer/sec:    118.81MB
+```
+
+#### With Bugpilot
+
+Bundle Size:
+
+```text
+Route (app)                              Size     First Load JS
+┌ ○ /                                    6.33 kB        90.8 kB
+└ ○ /_not-found                          924 B          85.4 kB
++ First Load JS shared by all            84.5 kB
+  ├ chunks/184-9b0dc1eb0ceb8b32.js       29 kB
+  ├ chunks/30b509c0-2b92d3406a54ba7e.js  53.4 kB
+  └ other shared chunks (total)          2.1 kB
+```
+
+Requests throughput:
+
+```text
+Running 30s test @ http://localhost:3200/
+  12 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    14.68ms   31.10ms 795.08ms   99.07%
+    Req/Sec   657.55     63.79     1.83k    91.86%
+  235400 requests in 30.10s, 3.72GB read
+Requests/sec:   7820.41
+Transfer/sec:    126.71MB
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bugpilot is a platform to catch production errors in your React applications. You can learn more and signup for free at [https://app.bugpilot.com](https://app.bugpilot.com).
 
-This Bugpilot plugin for Next.js (App Router) automatically captures errors in your Next.js application and sends them to your Bugpilot workspace.
+This Bugpilot plugin for Next.js (App Router) automatically captures errors in your Next.js application and sends them to your Bugpilot workspace. Bugpilot has a near-zero performance impact, see our [Performance](./PERFORMANCE.md) page for more details.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugpilot/plugin-nextjs",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Bugpilot for Next.js App Router",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/wrap-server-function.ts
+++ b/src/wrap-server-function.ts
@@ -1,21 +1,49 @@
 import { captureError } from "./capture-error";
 import { BugpilotBuildContext, NextError } from "./types";
 
+type UnknownFunctionType = (...args: unknown[]) => unknown | Promise<unknown>;
+type ArgsType = unknown[];
+
 export function wrapServerFunction(
-  fun: (...args: unknown[]) => unknown | Promise<unknown>,
+  fun: UnknownFunctionType,
   buildContext: BugpilotBuildContext,
 ) {
-  const bugpilotWrappedFunction = async (...args: unknown[]) => {
-    try {
-      const result: unknown = await fun(...args);
-      return result;
-    } catch (e) {
-      const err = e as NextError;
+  return new Proxy(fun, {
+    apply: (
+      originalFunction: UnknownFunctionType,
+      thisArg: unknown,
+      args: ArgsType,
+    ) => {
+      try {
+        // Call the original function with its 'this' and arguments.
+        const result: unknown | Promise<unknown> = originalFunction.apply(
+          thisArg,
+          args,
+        );
 
-      await captureError(err, buildContext);
-      throw err;
-    }
-  };
+        // If the result is a Promise, catch its rejections and
+        // capture the reason.
+        if (result instanceof Promise) {
+          // Do not return the result of this expression, you must
+          // return the original promise, instead.
+          Promise.resolve(result).catch((e) => {
+            const err = e as NextError;
+            void captureError(err, buildContext);
+          });
+        }
 
-  return bugpilotWrappedFunction;
+        // Return the original function result (or Promise), so the
+        // caller can await or .then()/.catch()
+        return result;
+      } catch (e) {
+        // Captures synchronous invokation errors (e.g., if the original function
+        // is not async)
+        const err = e as NextError;
+        void captureError(err, buildContext);
+
+        // Rethrow the error so the caller can handle it as usual with a try-catch
+        throw err;
+      }
+    },
+  });
 }


### PR DESCRIPTION
Calling .apply(...args) had some edge cases that caused unexpected errors. We are now using a Proxy to augment the apply() method so we can catch sync and async errors.